### PR TITLE
Allow keystrokes to pass through ScreenMixin

### DIFF
--- a/common/src/main/java/com/anthonyhilyard/equipmentcompare/mixin/ScreenMixin.java
+++ b/common/src/main/java/com/anthonyhilyard/equipmentcompare/mixin/ScreenMixin.java
@@ -28,7 +28,7 @@ public class ScreenMixin extends AbstractContainerEventHandler
 		EquipmentCompare.comparisonsActive = false;
 	}
 
-	@Inject(method = "keyPressed(III)Z", at = @At(value = "HEAD"), cancellable = true)
+	@Inject(method = "keyPressed(III)Z", at = @At(value = "RETURN"), cancellable = true)
 	public void keyPressed(int i, int j, int k, CallbackInfoReturnable<Boolean> info)
 	{
 		if (EquipmentCompare.showComparisonTooltip.matches(i, j))


### PR DESCRIPTION
fixes #45 

Allows user keystrokes to pass through super logic, fixing compatibility with various mods, while maintaining EquipmentCompare functionality.